### PR TITLE
all: add /raw/ handler and fix some backwards incompatible changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,17 @@ $ linksharing setup --defaults dev
 ### Production
 
 To configure the link sharing service for production, run the `setup` command
-using the `release` defaults. You must also provide the public URL for
-the sharing service, which is used to construct URLs returned to
+using the `release` defaults. An required argument is the location of the geo-location database.
+You must also provide the public URL for the sharing service, which is used to construct URLs returned to
 clients. Since there is currently no server affinity for requests, the URL
 can point to a pool of servers:
 
 ```
-$ linksharing setup --defaults release --public-url <PUBLIC URL>
+$ linksharing setup --defaults release --geo-location-db <PATH TO FILE> --public-url <PUBLIC URL> 
 ```
+
+**NOTE**: Please follow this link for instructions how to install/download the geo-location database:
+https://dev.maxmind.com/geoip/geoipupdate/
 
 Default release configuration has the link sharing service hosted on `:8443`
 serving HTTPS using a server certificate (`server.crt.pem`) and
@@ -55,3 +58,6 @@ After configuration is complete, running the link sharing is as simple as:
 ```
 $ linksharing run
 ```
+
+
+[Maxmind]: https://dev.maxmind.com/geoip/geoipupdate/

--- a/handler/handler.go
+++ b/handler/handler.go
@@ -277,9 +277,18 @@ func parseRequestPath(p string) (rawRequest bool, _ *uplink.Access, serializedAc
 
 	// Split the request path
 	segments := strings.SplitN(p, "/", 4)
-	if len(segments) == 4 && segments[0] == "raw" {
-		rawRequest = true
-		segments = segments[1:]
+	if len(segments) == 4 {
+		if segments[0] == "raw" {
+			rawRequest = true
+			segments = segments[1:]
+		} else {
+			// if its not a raw request, we need to concat the last two entries as those contain paths in the bucket
+			// and shrink the array again
+			rawRequest = false
+			segments[2] = segments[2] + "/" + segments[3]
+			segments = segments[:len(segments)-1]
+		}
+
 	}
 	if len(segments) == 1 {
 		if segments[0] == "" {


### PR DESCRIPTION
This change adds a /raw/ handler so one can request the files via the linksharing service
with a proper URL without query parameters.
EG: `https://link.tardigradeshare.io/raw/access/bucket/path/file.txt`
It also addresses the following backwards incompatible changes:
- changed default config directory
- incorrect binary name after go install
- moves the geoIP handling inside of the peer and tears it down the same way as all other services of it
- missing documentation of required flags