### PR TITLE
cmd/linksharing: move lets encrypt .certs dir into the config directory

### DIFF
--- a/cmd/linksharing/main.go
+++ b/cmd/linksharing/main.go
@@ -154,7 +154,7 @@ func configureLetsEncrypt(publicURL string) (tlsConfig *tls.Config, err error) {
 	certManager := autocert.Manager{
 		Prompt:     autocert.AcceptTOS,
 		HostPolicy: autocert.HostWhitelist(parsedURL.Host),
-		Cache:      autocert.DirCache(".certs"),
+		Cache:      autocert.DirCache(filepath.Join(confDir, ".certs")),
 	}
 	tlsConfig = &tls.Config{
 		GetCertificate: certManager.GetCertificate,


### PR DESCRIPTION
Currently the .certs dir is created in the location where the binary is executed,
which might be inconvenient. This change moves the .certs directory into the config dir.