### PR TITLE
Fix minimum zoom, disabling zoom out control

### DIFF
--- a/templates/single-object.html
+++ b/templates/single-object.html
@@ -27,6 +27,7 @@
 
                   L.tileLayer('https://api.mapbox.com/styles/v1/{id}/tiles/{z}/{x}/{y}?access_token=pk.eyJ1IjoiYnJhbmRvbnN0b3JqIiwiYSI6ImNrZzlrcG1lcDByemgycm11MHBiZ2VhcGUifQ.kp78EgYfoLWzePO0f9cWVQ', {
                     maxZoom: 6,
+                    minZoom: 1,
                     attribution: 'Map data &copy; <a href="https://www.openstreetmap.org/">OpenStreetMap</a> contributors, ' +
                             '<a href="https://creativecommons.org/licenses/by-sa/2.0/">CC-BY-SA</a>, ' +
                             'Imagery © <a href="https://www.mapbox.com/">Mapbox</a>',


### PR DESCRIPTION
Disable the zoom out button when at minimum zoom, otherwise the map would be blank and you see only the nodes.