### PR TITLE
Jenkinsfile: copy web folder into docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,7 @@ EXPOSE 7777
 WORKDIR /app
 VOLUME /root/.local/share/storj/linksharing
 COPY release/${TAG}/linksharing_linux_${GOARCH:-amd64} /app/linksharing
+COPY web/ /app/web/
 COPY entrypoint /entrypoint
 ENTRYPOINT ["/entrypoint"]
 ENV STORJ_CONFIG_DIR=/root/.local/share/storj/linksharing


### PR DESCRIPTION
Our linksharing service depends on the web folder files to operate, thus we need to copy them into the container for now.