### PR TITLE
.gitignore: add release folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@
 
 # avoid pushing maxmind databases
 *.mmdb
+
+# Ignore release directory
+release/


### PR DESCRIPTION
Make sure the release folder does not get commited or be accounted as change to the repo, when building images.